### PR TITLE
Fix syntax error on line 668 on newer perls

### DIFF
--- a/tabbedex
+++ b/tabbedex
@@ -665,7 +665,7 @@ package urxvt::ext::tabbedex::tab;
 # simply proxies all interesting calls back to the tabbedex class.
 
 {
-   for my $hook qw(start destroy user_command key_press property_notify add_lines) {
+   for my $hook (qw(start destroy user_command key_press property_notify add_lines)) {
       eval qq{
          sub on_$hook {
             my \$parent = \$_[0]{term}{parent}


### PR DESCRIPTION
Recent perls (anything after Perl 5.12) have removed the bug that let the qw// construct be used directly as the list in a for loop.  See http://www.nntp.perl.org/group/perl.perl5.porters/2010/08/msg163360.html for a technical discussion of the change to Perl 5.
